### PR TITLE
Minor adjustments to `Config.uk`

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,5 +1,5 @@
 menuconfig LIBCOMPILER_RT
-    bool " compiler-rt - runtime support"
+    bool "compiler-rt - runtime support"
     select LIBPOSIX_SYSINFO
     default n
 

--- a/Config.uk
+++ b/Config.uk
@@ -1,6 +1,6 @@
 menuconfig LIBCOMPILER_RT
     bool " compiler-rt - runtime support"
-    select UKSYSINFO
+    select LIBPOSIX_SYSINFO
     default n
 
 if LIBCOMPILER_RT


### PR DESCRIPTION
Rename `UKSYSINFO` dependency and remove leading whitespace in comment.