### PR TITLE
Config.uk: Add LIBUKMMAP dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,6 +1,7 @@
 menuconfig LIBCOMPILER_RT
     bool "compiler-rt - runtime support"
     select LIBPOSIX_SYSINFO
+    select LIBUKMMAP
     default n
 
 if LIBCOMPILER_RT


### PR DESCRIPTION
`mprotect()` is required and it is part of the `ukmmap` internal Unikraft library. Add required dependency to `Config.uk`.