### PR TITLE
Circular dependencies if adding libunwind as dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -2,6 +2,7 @@ menuconfig LIBCOMPILER_RT
     bool "compiler-rt - runtime support"
     select LIBPOSIX_SYSINFO
     select LIBUKMMAP
+    select LIBUNWIND
     default n
 
 if LIBCOMPILER_RT


### PR DESCRIPTION
libunwind already specifies compiler-rt as a dependency in its Config.uk. If we would add libunwind as a dependency in compiler-rt's Config.uk we would receive an error because there would be a circular dependency.

Signed-off-by: Delia-Maria Pavel <delia_maria.pavel@stud.acs.upb.ro>