### PR TITLE
Makefile.uk: Don't add unsupported warnings when built with clang

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -72,8 +72,9 @@ LIBCOMPILER_RT_CINCLUDES-$(call have_gcc) += -iquote$(LIBCOMPILER_RT_BASE)/inclu
 ################################################################################
 # Global flags
 ################################################################################
+
 LIBCOMPILER_RT_SUPPRESS_FLAGS-y += -Wno-unused-parameter
-LIBCOMPILER_RT_SUPPRESS_FLAGS-$(have_gcc) += -Wno-builtin-declaration-mismatch
+LIBCOMPILER_RT_SUPPRESS_FLAGS-$(call have_gcc) += -Wno-unused-but-set-variable -Wno-maybe-uninitialized -Wno-builtin-declaration-mismatch
 
 LIBCOMPILER_RT_CFLAGS-y   += $(LIBCOMPILER_RT_SUPPRESS_FLAGS-y)
 LIBCOMPILER_RT_CXXFLAGS-y += $(LIBCOMPILER_RT_SUPPRESS_FLAGS-y)


### PR DESCRIPTION
Part of the hackathon challenges, Fixes: #1

I couldn't reproduce the original issue with `-Wno-unused-but-set-variable -Wno-maybe-uninitialized`, but verified with `-Wno-builtin-declaration-mismatch`.

Authored by @Se7enBit, I'm just doing the commit/PR :)