### PR TITLE
build: Split off functionality that depends on libunwind

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -2,7 +2,6 @@ menuconfig LIBCOMPILER_RT
     bool "compiler-rt - runtime support"
     select LIBPOSIX_SYSINFO
     imply LIBUKMMAP
-    select LIBUNWIND
     default n
 
 if LIBCOMPILER_RT
@@ -10,4 +9,10 @@ if LIBCOMPILER_RT
     bool "Implementation of an atomics library"
     select CXX_THREADS
     default N
+
+    config LIBCOMPILER_RT_GCCPERSONALITY
+    bool "Implementation of GCC personality"
+    depends on LIBUNWIND
+    default N
+
 endif

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -38,7 +38,7 @@
 ################################################################################
 $(eval $(call addlib_s,libcompiler_rt,$(CONFIG_LIBCOMPILER_RT)))
 
-ifeq ($(CONFIG_LIBCOMPILER_RT),y)
+ifeq ($(CONFIG_LIBCOMPILER_RT_GCCPERSONALITY),y)
 ifneq ($(CONFIG_LIBUNWIND),y)
 $(error Require libunwind)
 endif
@@ -177,7 +177,6 @@ LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/floatuntisf.c
 LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/floatuntitf.c
 LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/floatuntixf.c
 LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/fp_mode.c
-LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/gcc_personality_v0.c
 LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/int_util.c
 LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/lshrdi3.c
 LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/lshrti3.c
@@ -245,6 +244,8 @@ LIBCOMPILER_RT_SRCS-y += $(LIBCOMPILER_RT_SRC)/lib/builtins/umodti3.c
 LIBCOMPILER_RT_SRCS-$(CONFIG_ARCH_X86_64) += $(LIBCOMPILER_RT_SRC)/lib/builtins/cpu_model.c
 LIBCOMPILER_RT_SRCS-$(CONFIG_ARCH_X86_64) += $(LIBCOMPILER_RT_SRC)/lib/builtins/x86_64/chkstk2.S
 LIBCOMPILER_RT_SRCS-$(CONFIG_ARCH_X86_64) += $(LIBCOMPILER_RT_SRC)/lib/builtins/x86_64/chkstk.S
+
+LIBCOMPILER_RT_SRCS-$(CONFIG_LIBCOMPILER_RT_GCCPERSONALITY) += $(LIBCOMPILER_RT_SRC)/lib/builtins/gcc_personality_v0.c
 
 LIBCOMPILER_RT_SRCS-$(CONFIG_LIBCOMPILER_RT_ATOMIC) += $(LIBCOMPILER_RT_SRC)/lib/builtins/atomic.c
 LIBCOMPILER_RT_SRCS-$(CONFIG_LIBCOMPILER_RT_ATOMIC) += $(LIBCOMPILER_RT_SRC)/lib/builtins/atomic_flag_clear.c


### PR DESCRIPTION
Previously lib-compiler-rt depended on libunwind as it pulled in <unwind.h>; this dependency however is isolated in gcc_personality_v0.c. This change makes gcc personality an optional part of lib-compiler-rt, allowing it to be built without an entire supporting C++ runtime.

This will allow lib-compiler-rt to be minimally pulled in when the compiler emits calls to builtin functions e.g., as discussed in https://github.com/unikraft/lib-musl/pull/46.

Tested on qemu-kvm-x86_64 with GCC 13 and clang 16.