### PR TITLE
Config.uk: Remove hard select of UKMMAP

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,7 +1,7 @@
 menuconfig LIBCOMPILER_RT
     bool "compiler-rt - runtime support"
     select LIBPOSIX_SYSINFO
-    select LIBUKMMAP
+    imply LIBUKMMAP
     select LIBUNWIND
     default n
 


### PR DESCRIPTION
Replace the hard `select` on UKMMAP with an `imply`, so one can select alternative mmap implemenations.