### PR TITLE
Makefile.uk: Upgrade to 15.0.0

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -47,7 +47,7 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBCOMPILER_RT_VERSION=14.0.6
+LIBCOMPILER_RT_VERSION=15.0.0
 LIBCOMPILER_RT_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCOMPILER_RT_VERSION)/compiler-rt-$(LIBCOMPILER_RT_VERSION).src.tar.xz
 LIBCOMPILER_RT_PATCHDIR=$(LIBCOMPILER_RT_BASE)/patches
 $(eval $(call fetch,libcompiler_rt,$(LIBCOMPILER_RT_URL)))


### PR DESCRIPTION
Upgrade compiler-rt to 15.0.0
Fixes: https://github.com/unikraft/lib-compiler-rt/issues/7

To build compiler-rt: add Unikraft Libs as:

`LIBS := $(UK_LIBS)/libcxxabi:$(UK_LIBS)/libcxx:$(UK_LIBS)/compiler-rt:$(UK_LIBS)/libunwind:$(UK_LIBS)/musl`

To build used gcc-11:
`make CC=gcc-11`