### PR TITLE
Makefile.uk: Remove redundant check for libunwind

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -38,12 +38,6 @@
 ################################################################################
 $(eval $(call addlib_s,libcompiler_rt,$(CONFIG_LIBCOMPILER_RT)))
 
-ifeq ($(CONFIG_LIBCOMPILER_RT_GCCPERSONALITY),y)
-ifneq ($(CONFIG_LIBUNWIND),y)
-$(error Require libunwind)
-endif
-endif
-
 ################################################################################
 # Sources
 ################################################################################


### PR DESCRIPTION
Commit b5b1cf8 (Split off functionality that depends on libunwind) removed the cyclic dependency between libunwind and libcompiler-rt and correctly expressed the relationship through Kconfig, making the build-time check for libunwind in Makefile.uk redundant. This change removes said redundant check.